### PR TITLE
Fixed Frame Attribute change

### DIFF
--- a/config/urdf_config.rviz
+++ b/config/urdf_config.rviz
@@ -270,7 +270,7 @@ Visualization Manager:
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
-    Fixed Frame: base_link
+    Fixed Frame: map
     Frame Rate: 30
   Name: root
   Tools:


### PR DESCRIPTION
Due to `base_link` has moving attributes aka is a moving joint and according to ros wiki;

`the fixed frame should not be moving relative to the world.` 

Those changes should fix the extrapolation error.